### PR TITLE
`missed_attestations`: Remove useless assert.

### DIFF
--- a/eth_validator_watcher/missed_attestations.py
+++ b/eth_validator_watcher/missed_attestations.py
@@ -77,9 +77,6 @@ def handle_missed_attestation_detection(
         beacon.aggregate_attestations_from_previous_slot(data_block.slot)
     )
 
-    actual_committies_index = actual_committee_index_to_validator_attestation_success
-    assert set(previous_slot_duty_committies_index) == set(actual_committies_index)
-
     list_of_ok_vals_index = (
         apply_mask(
             previous_slot_duty_committies_index[committee_index],


### PR DESCRIPTION
We just iterate over currently present committies. If some committies were on duty but did not actually vote, we don't use them at all.