### PR TITLE
enh(grafana): switch to the SVG version of the ETH logo

### DIFF
--- a/grafana_dashboard.json
+++ b/grafana_dashboard.json
@@ -308,7 +308,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "<img src=https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Eth-diamond-rainbow.png/800px-Eth-diamond-rainbow.png height=\"auto\" width=\"auto\"/>\n",
+        "content": "<img src=\"https://ethereum.org/static/eth-diamond-rainbow.svg\" height=\"auto\" width=\"auto\"/>\n",
         "mode": "html"
       },
       "pluginVersion": "9.3.2",


### PR DESCRIPTION
SVGs are smaller, and will adapt to any pixel density