### PR TITLE
Add help message in case of bad `--beacon-type` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ You did not had ideal target rewards. | ```🎯 Our validator 0x8000118f, 0x80a2
 You did not had ideal head rewards. | ```🗣️ Our validator 0x8005f5e8, 0x801910e5, 0x80193dd5, 0x801a26e9, 0x80285258 and 0 more had not ideal rewards on head  at epoch 215200```
 The chain is not yet started.       | ```⏱️     The chain will start in  1 days,  1 hours,  3 minutes and 48 seconds.```
 
+If you see this kind of message:
+```
+❓     Missed attestations detection is disabled for epoch 238030.
+❓     You can ignore this message if the watcher just started less than one epoch ago. Otherwise, please check that you used the correct `--beacon-type`` option (currently set to `other`).
+❓     Use `--help` for more details.
+```
+
+If you just started the watcher less than one epoch ago (and especially, if you started the watcher during the few last slots of the epoch), then you can safely ignore this message.
+Otherwise, please check you uses the correct `--beacon-type` option.
+
 Slack messages
 --------------
 If a Slack channel is specified, the slack messages are sent according to the following events:

--- a/eth_validator_watcher/beacon.py
+++ b/eth_validator_watcher/beacon.py
@@ -338,9 +338,16 @@ class Beacon:
             # If we are here, it means the requested epoch is too old, which
             # could be normal if the watcher just started
             print(
-                f"👵     Liveness requested epoch is too old: {epoch}. "
-                "This message should be displayed only at the watcher start."
+                f"❓     Missed attestations detection is disabled for epoch {epoch}. "
             )
+
+            print(
+                "❓     You can ignore this message if the watcher just started less "
+                "than one epoch ago. Otherwise, please check that you used the correct "
+                f"`--beacon-type` option (currently set to `{beacon_type}`). "
+            )
+
+            print("❓     Use `--help` for more details.")
 
             return {index: True for index in validators_index}
 

--- a/eth_validator_watcher/entrypoint.py
+++ b/eth_validator_watcher/entrypoint.py
@@ -78,8 +78,7 @@ net_active_validators_gauge = Gauge(
 def handler(
     beacon_url: str = Option(..., help="URL of beacon node", show_default=False),
     execution_url: str = Option(None, help="URL of execution node", show_default=False),
-    pubkeys_file_path: Path
-    | None = Option(
+    pubkeys_file_path: Optional[Path] = Option(
         None,
         help="File containing the list of public keys to watch",
         exists=True,
@@ -87,18 +86,15 @@ def handler(
         dir_okay=False,
         show_default=False,
     ),
-    web3signer_url: str
-    | None = Option(
+    web3signer_url: Optional[str] = Option(
         None, help="URL to web3signer managing keys to watch", show_default=False
     ),
-    fee_recipient: str
-    | None = Option(
+    fee_recipient: Optional[str] = Option(
         None,
         help="Fee recipient address - --execution-url must be set",
         show_default=False,
     ),
-    slack_channel: str
-    | None = Option(
+    slack_channel: Optional[str] = Option(
         None,
         help="Slack channel to send alerts - SLACK_TOKEN env var must be set",
         show_default=False,
@@ -120,7 +116,9 @@ def handler(
     relay_url: List[str] = Option(
         [], help="URL of allow listed relay", show_default=False
     ),
-    liveness_file: Path | None = Option(None, help="Liveness file", show_default=False),
+    liveness_file: Optional[Path] = Option(
+        None, help="Liveness file", show_default=False
+    ),
 ) -> None:
     """
     🚨 Ethereum Validator Watcher 🚨


### PR DESCRIPTION
```
✅     validator 0x875fc22c proposed block at head at epoch 238032 - slot 7617038 ✅ - 🔑 32035 keys watched
✅     validator 0xb2da1ce0 proposed block at head at epoch 238032 - slot 7617039 ✅ - 🔑 32035 keys watched
❓     Missed attestations detection diabled for epoch 238031.
❓     You can ignore this message if the watcher just started less than one epoch ago. Otherwise, please check that you used the correct `--beacon-type` option (currently set to `other`).
❓     Use `--help` for more details.
✅     validator 0x8659ab70 proposed block at head at epoch 238032 - slot 7617040 ✅ - 🔑 32035 keys watched
👤 Our validator 0x803028d6, 0x804e28e0, 0x804eeee5, 0x8051ab55, 0x8075bbc4 and 228 more had not ideal rewards on head  at epoch 238030 (0.74%)
✅     validator 0xa8f44816 proposed block at head at epoch 238032 - slot 7617041 ✅ - 🔑 32035 keys watched
✅     validator 0xa29ad72e proposed block at head at epoch 238032 - slot 7617042 ✅ - 🔑 32035 keys watched
✅     validator 0xacf8e5ff proposed block at head at epoch 238032 - slot 7617043 ✅ - 🔑 32035 keys watched
```