### PR TITLE
fix(helm): use python3.11 for probes and update appVersion to 0.7.1

### DIFF
--- a/charts/eth-validator-watcher/Chart.yaml
+++ b/charts/eth-validator-watcher/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for running eth-validator-watcher
 name: eth-validator-watcher
 type: application
 version: 1.3.0
-appVersion: v0.7.1
+appVersion: 0.7.1
 maintainers:
   - name: Alluvial
     email: contact@alluvial.finance

--- a/charts/eth-validator-watcher/Chart.yaml
+++ b/charts/eth-validator-watcher/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: A Helm chart for running eth-validator-watcher
 name: eth-validator-watcher
 type: application
-version: 1.2.0
-appVersion: v0.4.2
+version: 1.3.0
+appVersion: v0.7.1
 maintainers:
   - name: Alluvial
     email: contact@alluvial.finance

--- a/charts/eth-validator-watcher/README.md
+++ b/charts/eth-validator-watcher/README.md
@@ -1,6 +1,6 @@
 # eth-validator-watcher
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.2](https://img.shields.io/badge/AppVersion-v0.4.2-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.1](https://img.shields.io/badge/AppVersion-v0.7.1-informational?style=flat-square)
 
 A Helm chart for running eth-validator-watcher
 

--- a/charts/eth-validator-watcher/README.md
+++ b/charts/eth-validator-watcher/README.md
@@ -1,6 +1,6 @@
 # eth-validator-watcher
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.1](https://img.shields.io/badge/AppVersion-v0.7.1-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
 
 A Helm chart for running eth-validator-watcher
 

--- a/charts/eth-validator-watcher/templates/deployment.yaml
+++ b/charts/eth-validator-watcher/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /usr/bin/python3.9
+            - /usr/bin/python3.11
             - /usr/local/bin/liveness_check.py
             - /tmp/liveness
           initialDelaySeconds: {{ .initialDelaySeconds }}
@@ -76,7 +76,7 @@ spec:
         readinessProbe:
           exec:
             command:
-            - /usr/bin/python3.9
+            - /usr/bin/python3.11
             - /usr/local/bin/liveness_check.py
             - /tmp/liveness
           initialDelaySeconds: {{ .initialDelaySeconds }}


### PR DESCRIPTION
`v0.7.0` introduced a new required version of python (`3.11` instead of `3.9`) so this updates the probes (liveness/readiness).

The `appVersion` was prefixed by `v` but the images produced by the repo are not prefixed by `v`, making default not working as is. This PR fixes it and set the `appVersion` to `0.7.1` (latest to date).