### PR TITLE
feat: support custom seconds per slot and slots per epoch

### DIFF
--- a/eth_validator_watcher/beacon.py
+++ b/eth_validator_watcher/beacon.py
@@ -17,6 +17,7 @@ from .models import (
     BlockIdentierType,
     Committees,
     Genesis,
+    Spec,
     Header,
     ProposerDuties,
     Rewards,
@@ -120,6 +121,15 @@ class Beacon:
         genesis_dict = response.json()
         return Genesis(**genesis_dict)
 
+    def get_spec(self) -> Spec:
+        """Get network specification."""
+        response = self.__get_retry_not_found(
+            f"{self.__url}/eth/v1/config/spec", timeout=TIMEOUT_BEACON_SEC
+        )
+        response.raise_for_status()
+        spec_dict = response.json()
+        return Spec(**spec_dict)
+
     def get_header(self, block_identifier: Union[BlockIdentierType, int]) -> Header:
         """Get a header.
 
@@ -129,7 +139,8 @@ class Beacon:
         """
         try:
             response = self.__get(
-                f"{self.__url}/eth/v1/beacon/headers/{block_identifier}", timeout=TIMEOUT_BEACON_SEC
+                f"{self.__url}/eth/v1/beacon/headers/{block_identifier}",
+                timeout=TIMEOUT_BEACON_SEC,
             )
 
             response.raise_for_status()
@@ -176,7 +187,8 @@ class Beacon:
         epoch: Epoch corresponding to the proposer duties to retrieve
         """
         response = self.__get_retry_not_found(
-            f"{self.__url}/eth/v1/validator/duties/proposer/{epoch}", timeout=TIMEOUT_BEACON_SEC
+            f"{self.__url}/eth/v1/validator/duties/proposer/{epoch}",
+            timeout=TIMEOUT_BEACON_SEC,
         )
 
         response.raise_for_status()
@@ -193,7 +205,8 @@ class Beacon:
         inner value             : Validator
         """
         response = self.__get_retry_not_found(
-            f"{self.__url}/eth/v1/beacon/states/head/validators", timeout=TIMEOUT_BEACON_SEC
+            f"{self.__url}/eth/v1/beacon/states/head/validators",
+            timeout=TIMEOUT_BEACON_SEC,
         )
 
         response.raise_for_status()

--- a/eth_validator_watcher/entrypoint.py
+++ b/eth_validator_watcher/entrypoint.py
@@ -396,10 +396,21 @@ def _handler(
 
             last_rewards_process_epoch = epoch
 
-        process_future_blocks_proposal(beacon, our_pubkeys, slot, is_new_epoch)
+        process_future_blocks_proposal(
+            beacon,
+            our_pubkeys,
+            slot,
+            is_new_epoch,
+            slots_per_epoch=slots_per_epoch,
+        )
 
         last_processed_finalized_slot = process_missed_blocks_finalized(
-            beacon, last_processed_finalized_slot, slot, our_pubkeys, slack
+            beacon,
+            last_processed_finalized_slot,
+            slot,
+            our_pubkeys,
+            slack,
+            slots_per_epoch=slots_per_epoch,
         )
 
         delta_sec = MISSED_BLOCK_TIMEOUT_SEC - (time() - slot_start_time_sec)
@@ -415,6 +426,7 @@ def _handler(
                 block,
                 slot,
                 our_active_idx2val,
+                slots_per_epoch=slots_per_epoch,
             )
 
             process_fee_recipient(

--- a/eth_validator_watcher/fee_recipient.py
+++ b/eth_validator_watcher/fee_recipient.py
@@ -19,6 +19,7 @@ def process_fee_recipient(
     execution: Execution | None,
     expected_fee_recipient: str | None,
     slack: Slack | None,
+    slots_per_epoch: int = NB_SLOT_PER_EPOCH,
 ) -> None:
     """Check if the fee recipient is the one expected.
 
@@ -44,7 +45,7 @@ def process_fee_recipient(
 
     short_proposer_pubkey = index_to_validator[proposer_index].pubkey[:10]
     slot = block.data.message.slot
-    epoch = slot // NB_SLOT_PER_EPOCH
+    epoch = slot // slots_per_epoch
 
     # First, we check if the beacon block fee recipient is the one expected
     # `.lower()` is here just in case the execution client returns a fee recipient in

--- a/eth_validator_watcher/missed_blocks.py
+++ b/eth_validator_watcher/missed_blocks.py
@@ -27,6 +27,7 @@ def process_missed_blocks_head(
     slot: int,
     our_pubkeys: set[str],
     slack: Slack | None,
+    slots_per_epoch: int = NB_SLOT_PER_EPOCH,
 ) -> bool:
     """Process missed block proposals detection at head
 
@@ -40,7 +41,7 @@ def process_missed_blocks_head(
     Returns `True` if we had to propose the block, `False` otherwise
     """
     missed = potential_block is None
-    epoch = slot // NB_SLOT_PER_EPOCH
+    epoch = slot // slots_per_epoch
     proposer_duties = beacon.get_proposer_duties(epoch)
 
     # Get proposer public key for this slot
@@ -98,6 +99,7 @@ def process_missed_blocks_finalized(
     slot: int,
     our_pubkeys: set[str],
     slack: Slack | None,
+    slots_per_epoch: int = NB_SLOT_PER_EPOCH,
 ) -> int:
     """Process missed block proposals detection at finalized
 
@@ -114,14 +116,14 @@ def process_missed_blocks_finalized(
 
     last_finalized_header = beacon.get_header(BlockIdentierType.FINALIZED)
     last_finalized_slot = last_finalized_header.data.header.message.slot
-    epoch_of_last_finalized_slot = last_finalized_slot // NB_SLOT_PER_EPOCH
+    epoch_of_last_finalized_slot = last_finalized_slot // slots_per_epoch
 
     # Only to memoize it, in case of the BN does not serve this request for too old
     # epochs
     beacon.get_proposer_duties(epoch_of_last_finalized_slot)
 
     for slot_ in range(last_processed_finalized_slot + 1, last_finalized_slot + 1):
-        epoch = slot_ // NB_SLOT_PER_EPOCH
+        epoch = slot_ // slots_per_epoch
         proposer_duties = beacon.get_proposer_duties(epoch)
 
         # Get proposer public key for this slot

--- a/eth_validator_watcher/models.py
+++ b/eth_validator_watcher/models.py
@@ -38,6 +38,14 @@ class Genesis(BaseModel):
     data: Data
 
 
+class Spec(BaseModel):
+    class Data(BaseModel):
+        SECONDS_PER_SLOT: int
+        SLOTS_PER_EPOCH: int
+
+    data: Data
+
+
 class Header(BaseModel):
     class Data(BaseModel):
         class Header(BaseModel):

--- a/eth_validator_watcher/next_blocks_proposal.py
+++ b/eth_validator_watcher/next_blocks_proposal.py
@@ -20,6 +20,7 @@ def process_future_blocks_proposal(
     our_pubkeys: set[str],
     slot: int,
     is_new_epoch: bool,
+    slots_per_epoch: int = NB_SLOT_PER_EPOCH,
 ) -> int:
     """Handle next blocks proposal
 
@@ -29,7 +30,7 @@ def process_future_blocks_proposal(
     slot        : Slot
     is_new_epoch: Is new epoch
     """
-    epoch = slot // NB_SLOT_PER_EPOCH
+    epoch = slot // slots_per_epoch
     proposers_duties_current_epoch = beacon.get_proposer_duties(epoch)
     proposers_duties_next_epoch = beacon.get_proposer_duties(epoch + 1)
 

--- a/eth_validator_watcher/suboptimal_attestations.py
+++ b/eth_validator_watcher/suboptimal_attestations.py
@@ -29,6 +29,7 @@ def process_suboptimal_attestations(
     block: Block,
     slot: int,
     our_active_validators_index_to_validator: dict[int, Validators.DataItem.Validator],
+    slots_per_epoch: int = NB_SLOT_PER_EPOCH,
 ) -> set[int]:
     """Process sub-optimal attestations
 
@@ -48,7 +49,7 @@ def process_suboptimal_attestations(
 
     # Epoch of previous slot is NOT the previous epoch, but really the epoch
     # corresponding to the previous slot.
-    epoch_of_previous_slot = previous_slot // NB_SLOT_PER_EPOCH
+    epoch_of_previous_slot = previous_slot // slots_per_epoch
 
     # All our active validators index
     our_active_validators_index = set(our_active_validators_index_to_validator)
@@ -133,7 +134,9 @@ def process_suboptimal_attestations(
     )
 
     if suboptimal_attestations_rate is not None:
-        metric_suboptimal_attestations_rate_gauge.set(100 * suboptimal_attestations_rate)
+        metric_suboptimal_attestations_rate_gauge.set(
+            100 * suboptimal_attestations_rate
+        )
 
     if len(our_validators_index_that_did_not_attest_optimally_during_previous_slot) > 0:
         assert suboptimal_attestations_rate is not None

--- a/eth_validator_watcher/utils.py
+++ b/eth_validator_watcher/utils.py
@@ -231,12 +231,15 @@ class Slack:
         self.__client.chat_postMessage(channel=self.__channel, text=message)
 
 
-def slots(genesis_time_sec: int) -> Iterator[Tuple[int, int]]:
-    next_slot = int((time() - genesis_time_sec) / NB_SECOND_PER_SLOT) + 1
+def slots(
+    genesis_time_sec: int,
+    seconds_per_slot: int = NB_SECOND_PER_SLOT,
+) -> Iterator[Tuple[int, int]]:
+    next_slot = int((time() - genesis_time_sec) / seconds_per_slot) + 1
 
     try:
         while True:
-            next_slot_time_sec = genesis_time_sec + next_slot * NB_SECOND_PER_SLOT
+            next_slot_time_sec = genesis_time_sec + next_slot * seconds_per_slot
             time_to_wait = next_slot_time_sec - time()
             sleep(max(0, time_to_wait))
 


### PR DESCRIPTION
Load `SLOTS_PER_EPOCH` and `SECONDS_PER_SLOT` specification params from [Beacon API](https://ethereum.github.io/beacon-APIs/#/Config/getSpec) instead of using constants. This change gives support for [Gnosis Chain](https://www.gnosis.io/) based networks.